### PR TITLE
Minute blinking and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TFWordclock
 Repository for Tempus Fugit WordClock s/w and build instructions
 
+```
 Usage: Wordclockr5.py [-h] [-r count] [-b bklopt]  [{English,French,Dutch,German}]
  
 positional arguments:  
@@ -15,7 +16,7 @@ optional arguments:
                         blink - 0 = board act led only 1:1, 1 = minute
                         indication blinking (ignored for French), 2 = board
                         act led only 1:10, 3 = act led off (default: 0)  
-
+```
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -3,34 +3,33 @@ Repository for Tempus Fugit WordClock s/w and build instructions
 
 Usage: Wordclockr5.py [-h] [-r count] [-b bklopt]  [{English,French,Dutch,German}]
  
-positional arguments:
-  {English,French,Dutch,German} 
-                        Language: English, French, Dutch or German (default:English)
-optional arguments:
-  -h, --help            show this help message and exit
-  -r count, --rotation count
+positional arguments:  
+  {English,French,Dutch,German}   
+                        Language: English, French, Dutch or German (default:English)  
+optional arguments:  
+  -h, --help            show this help message and exit  
+  -r count, --rotation count  
                         Rotation - 0 = upright, 1 = rotated 90 clockwise, 2 =
-                        upside down and 3 = 90 counter-clockwise (default: 0)
-  -b bklopt, --blink bklopt
+                        upside down and 3 = 90 counter-clockwise (default: 0)  
+  -b bklopt, --blink bklopt  
                         blink - 0 = board act led only 1:1, 1 = minute
                         indication blinking (ignored for French), 2 = board
-                        act led only 1:10, 3 = act led off (default: 0)
+                        act led only 1:10, 3 = act led off (default: 0)  
 
 
 Notes:
 
-Rev 5
+Rev 5  
 Language handling change for rev 5 - see python code
 
 Wordclockrx.py and timewrdxca_xx.py must be in the same directory
-where x is the current revision code
+where x is the current revision code.  
 TFW_data file must be in TFWordclock directory 
 
 Current versions
 
-   Wordclockr5.py
-   timewrd5ca_eng.py
-   timewrd5ca_fr.py
-   timewrd5ca_du.py
-   timewrd5ca_ger.py
-
+   Wordclockr5.py  
+   timewrd5ca_eng.py  
+   timewrd5ca_fr.py  
+   timewrd5ca_du.py  
+   timewrd5ca_ger.py  

--- a/README.md
+++ b/README.md
@@ -1,33 +1,36 @@
 # TFWordclock
 Repository for Tempus Fugit WordClock s/w and build instructions
 
-Usage: Wordclockr5.py [-h] [-b bklopt]  [{English,French,Dutch,German}]
+Usage: Wordclockr5.py [-h] [-r count] [-b bklopt]  [{English,French,Dutch,German}]
  
 positional arguments:
-  {English,French,Dutch,German}   [German not current available]
+  {English,French,Dutch,German} 
                         Language: English, French, Dutch or German (default:English)
 optional arguments:
   -h, --help            show this help message and exit
+  -r count, --rotation count
+                        Rotation - 0 = upright, 1 = rotated 90 clockwise, 2 =
+                        upside down and 3 = 90 counter-clockwise (default: 0)
   -b bklopt, --blink bklopt
-                        blink - 0 = board act led only 1:1, 1 = minute flash, 2 = 10sec flash,
-3 =act led off (default: 0)
+                        blink - 0 = board act led only 1:1, 1 = minute
+                        indication blinking (ignored for French), 2 = board
+                        act led only 1:10, 3 = act led off (default: 0)
 
 
 Notes:
 
-German version not currently implemented
-
 Rev 5
 Language handling change for rev 5 - see python code
-Rotation now implimented in hardcode - see instructions
 
-Wordclockrx.py and timewrdxca.py must be in the same directory
+Wordclockrx.py and timewrdxca_xx.py must be in the same directory
+where x is the current revision code
 TFW_data file must be in TFWordclock directory 
 
-where x is the current revision code
 Current versions
 
    Wordclockr5.py
-   timewrd5ca_en.py
+   timewrd5ca_eng.py
+   timewrd5ca_fr.py
+   timewrd5ca_du.py
+   timewrd5ca_ger.py
 
-[there never was and Wordclockr4]

--- a/timewrd5ca_eng.py
+++ b/timewrd5ca_eng.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
 # Python Class for use on word clock project
-# Assumes and 8x8 matrix common anode type
+# Assumes an 8x8 matrix common anode type
 # David Saul 2018
 # This is configured for the PCB layout REV 4 onwards
 
 # From version 5
-# 	class has changed to use the luma.led_matrix libuary
-# 	this is not compatable with earlier vesions using the max7219 which is
-#	if effectcivly obsolete from Dec 2017
+# 	Class has changed to use the luma.led_matrix library
+# 	This is not compatible with earlier versions using the max7219 library which is
+#	effectcivly obsolete from Dec 2017
 #
-#	each language has it's own timewrd file in the format timewrd5ca_eng.py
-#	this avoids this file getting too ungainly and also makes it eaiser
-#	to add support for other display in the future
+#	Each language has it's own timewrd file in the format timewrd5ca_eng.py
+#	This avoids this file getting too ungainly and also makes it easier
+#	to add support for other displays in the future
 #
-#	support for various status symbol display has changed
+#	Support for various status symbol displays has changed
 #
 #
 # +++++++++++++++
@@ -25,100 +25,84 @@
 #
 # This class is written to work with the TFWordclock App version 5 and higher
 
-# Because of the change of libuary some version 4 features are slightly different / no longer supported
-#
-#
-# --- display rotation  - this is now controlled by setting the variable 'rotation' below
-# --- blink to indicate time within 5 minute incruments - no plans to re-impliment
-# --- the various warning are not impliemented as 'count downs' rather than moving bars
+# Because of the change of libuary some version 4 features are slightly different
+# --- the various warning are now implemented as 'count downs' rather than moving bars
 
 
 # luma.led_matrix libuary - Richard Hull
 # https://github.com/rm-hull/luma.led_matrix
 #
 
+from __future__ import print_function, division
+
 from luma.core.interface.serial import spi, noop
 from luma.core.render import canvas
 from luma.led_matrix.device import max7219
 from time import sleep
-
-#-----------------------------------------------------
-rotation = 0		#set global rotate (0,1,2,3)
-#-----------------------------------------------------
-
-
-serial = spi(port=0, device=0, gpio=noop())
-device = max7219(serial, rotate = rotation)
-
-
-import math
 from PIL import Image
 
 
 # English Class
 class DMS_wrdck:
 
+	def __init__(self, rotation = 0):
+		serial = spi(port=0, device=0, gpio=noop())
+		self.device = max7219(serial, rotate = rotation)
 
-	def ckdisp(self,mint,hour, prefix=False, rot=0):
-
+	def ckdisp(self,mint,hour, prefix=False, blink='none'):
 
 		# Perfor basic error check on variables
-	        if mint < 0 or mint > 59:
-        		return
-	        if hour < -1 or hour > 24:
-        	        return
+		if mint < 0 or mint > 59:
+			return
+		if hour < -1 or hour > 24:
+			return
 
-#	        # Correct from 24 hour to 12
- #       	if hour == 0:
-                	hour =12
-#
-#		if hour > 12:
-#			hour = hour - 12
-
-	        # Clear the display first by generating new image
+		# Clear the display first by generating new image
 
 		image = Image.new('1', (8, 8))
 
 		# Display additional charater if needed
-		if prefix == 'A':		#Display astrix - for time setting mode
+		if prefix == 'A':		# Display astrix
 			image.putpixel((2, 2), 1)
-		elif prefix == 'V':		#Display V - to indicate version number
+		elif prefix == 'V':		# Display V - to indicate version number
 			image.putpixel((3, 1), 1)
 		else:
 			pass
 
-		# Convert minutes into 5 minute slots, with true rounding
-        	min = int(round(mint / 5.0))
-#                print mint, int(round(mint /5.0))	#debug only
+		# Convert minutes into 5 minute slots, with true rounding if no minute blinking
+		if blink == 'none':
+			min = int(round(mint / 5.0))
+		else:
+			min = mint // 5
 
 		# Increment 'hour' for > 30 mins past the hour
-		if min > 6 and hour != -1:	#except for special case when hour is inhibited
-			hour = hour +1
+		if min > 6 and hour != -1:	# Except for special case when hour is inhibited
+			hour = hour + 1
 			if hour == 24:
 				hour = 12
 
-                # Correct from 24 hour to 12
-                if hour == 0:
-                        hour =12
+		# Correct from 24 hour to 12
+		if hour == 0:
+			hour = 12
 
-                if hour > 12:
-                        hour = hour - 12
+		if hour > 12:
+			hour = hour - 12
 
-		#correct for final 2/3 minutes in the hour
-                if min == 12:
-                        min = 0
+		# Correct for final 2/3 minutes in the hour (only used when no minute blinking)
+		if min == 12:
+			min = 0
 
-		# Bodge to blank hours display during minute setup
-		# if hour = -1 force it to 0 so it does not display
-#		if hour == -1:
-#			hour = 0
-
-#		print "min lookup ",min		# for debug only
+		if blink == 'off':
+			if min == 0:
+				hour = -1
+			else:
+				min = 0
 
 		# Display minutes past / to the hour in to nearest 5 minute 'slot'
-		if min == 0:	#oclock
+		if min == 0:	# oclock
 			pass
-		elif min ==1:	#five_past
+
+		elif min == 1:	# five_past
 			image.putpixel((0, 1), 1)
 			image.putpixel((1, 1), 1)
 			image.putpixel((3, 1), 1)
@@ -128,7 +112,7 @@ class DMS_wrdck:
 			image.putpixel((5, 2), 1)
 			image.putpixel((6, 2), 1)
 
-		elif min ==2:	#ten_past
+		elif min == 2:	# ten_past
 			image.putpixel((4, 1), 1)
 			image.putpixel((6, 1), 1)
 			image.putpixel((7, 1), 1)
@@ -137,7 +121,7 @@ class DMS_wrdck:
 			image.putpixel((5, 2), 1)
 			image.putpixel((6, 2), 1)
 
-		elif min ==3:	#fifteen_past
+		elif min == 3:	# fifteen_past
 			image.putpixel((0, 1), 1)
 			image.putpixel((1, 1), 1)
 			image.putpixel((2, 1), 1)
@@ -150,7 +134,7 @@ class DMS_wrdck:
 			image.putpixel((5, 2), 1)
 			image.putpixel((6, 2), 1)
 
-		elif min ==4:	#tweny_past
+		elif min == 4:	# tweny_past
 			image.putpixel((2, 0), 1)
 			image.putpixel((3, 0), 1)
 			image.putpixel((4, 0), 1)
@@ -162,7 +146,7 @@ class DMS_wrdck:
 			image.putpixel((5, 2), 1)
 			image.putpixel((6, 2), 1)
 
-		elif min ==5:	#twenty5_past
+		elif min == 5:	# twenty5_past
 			image.putpixel((2, 0), 1)
 			image.putpixel((3, 0), 1)
 			image.putpixel((4, 0), 1)
@@ -178,7 +162,7 @@ class DMS_wrdck:
 			image.putpixel((5, 2), 1)
 			image.putpixel((6, 2), 1)
 
-		elif min ==6:	#half_past
+		elif min == 6:	# half_past
 			image.putpixel((0, 0), 1)
 			image.putpixel((1, 0), 1)
 			image.putpixel((0, 2), 1)
@@ -188,7 +172,7 @@ class DMS_wrdck:
 			image.putpixel((5, 2), 1)
 			image.putpixel((6, 2), 1)
 
-		elif min ==7:	#twenty5_to
+		elif min == 7:	# twenty5_to
 			image.putpixel((2, 0), 1)
 			image.putpixel((3, 0), 1)
 			image.putpixel((4, 0), 1)
@@ -202,7 +186,7 @@ class DMS_wrdck:
 			image.putpixel((6, 2), 1)
 			image.putpixel((7, 2), 1)
 
-		elif min ==8:	#twenty_to
+		elif min == 8:	# twenty_to
 			image.putpixel((2, 0), 1)
 			image.putpixel((3, 0), 1)
 			image.putpixel((4, 0), 1)
@@ -212,7 +196,7 @@ class DMS_wrdck:
 			image.putpixel((6, 2), 1)
 			image.putpixel((7, 2), 1)
 
-		elif min ==9:	#fifteen_to
+		elif min == 9:	# fifteen_to
 			image.putpixel((0, 1), 1)
 			image.putpixel((1, 1), 1)
 			image.putpixel((2, 1), 1)
@@ -223,14 +207,14 @@ class DMS_wrdck:
 			image.putpixel((6, 2), 1)
 			image.putpixel((7, 2), 1)
 
-		elif min ==10:	#ten_to
+		elif min == 10:	# ten_to
 			image.putpixel((4, 1), 1)
 			image.putpixel((5, 1), 1)
 			image.putpixel((7, 1), 1)
 			image.putpixel((6, 2), 1)
 			image.putpixel((7, 2), 1)
 
-		else:	#five_to
+		else:	# five_to
 			image.putpixel((0, 1), 1)
 			image.putpixel((1, 1), 1)
 			image.putpixel((3, 1), 1)
@@ -238,179 +222,173 @@ class DMS_wrdck:
 			image.putpixel((6, 2), 1)
 			image.putpixel((7, 2), 1)
 
-#	        print "sub ",hour,":", min              #For debug only
-
 		# Display the hours
 		if hour == -1: # blank hour display
 			pass
 
-		elif hour == 1:	#one
-	                image.putpixel((0, 4), 1)
-        	        image.putpixel((1, 4), 1)
-	                image.putpixel((2, 4), 1)
+		elif hour == 1:		# one
+			image.putpixel((0, 4), 1)
+			image.putpixel((1, 4), 1)
+			image.putpixel((2, 4), 1)
 
-		elif hour ==2:	#two
+		elif hour == 2:		# two
 			image.putpixel((0, 5), 1)
-                	image.putpixel((1, 5), 1)
-	                image.putpixel((1, 6), 1)
+			image.putpixel((1, 5), 1)
+			image.putpixel((1, 6), 1)
 
-		elif hour ==3:	#three
-        	        image.putpixel((3, 4), 1)
-	                image.putpixel((4, 4), 1)
-        	        image.putpixel((5, 4), 1)
-	                image.putpixel((6, 4), 1)
-        	        image.putpixel((7, 4), 1)
+		elif hour == 3:		# three
+			image.putpixel((3, 4), 1)
+			image.putpixel((4, 4), 1)
+			image.putpixel((5, 4), 1)
+			image.putpixel((6, 4), 1)
+			image.putpixel((7, 4), 1)
 
-		elif hour ==4:	#four
-                	image.putpixel((0, 6), 1)
-	                image.putpixel((1, 6), 1)
-        	        image.putpixel((2, 6), 1)
-	                image.putpixel((3, 6), 1)
+		elif hour == 4:		# four
+			image.putpixel((0, 6), 1)
+			image.putpixel((1, 6), 1)
+			image.putpixel((2, 6), 1)
+			image.putpixel((3, 6), 1)
 
-		elif hour ==5:	#five
-        	        image.putpixel((4, 6), 1)
-                	image.putpixel((5, 6), 1)
-	                image.putpixel((6, 6), 1)
-        	        image.putpixel((7, 6), 1)
+		elif hour == 5:		# five
+			image.putpixel((4, 6), 1)
+			image.putpixel((5, 6), 1)
+			image.putpixel((6, 6), 1)
+			image.putpixel((7, 6), 1)
 
-		elif hour ==6:	#six
-                	image.putpixel((0, 7), 1)
-	                image.putpixel((1, 7), 1)
-        	        image.putpixel((2, 7), 1)
+		elif hour == 6:		# six
+			image.putpixel((0, 7), 1)
+			image.putpixel((1, 7), 1)
+			image.putpixel((2, 7), 1)
 
-		elif hour ==7:	#seven
-	                image.putpixel((3, 7), 1)
-        	        image.putpixel((4, 7), 1)
-                	image.putpixel((5, 7), 1)
-	                image.putpixel((6, 7), 1)
-        	        image.putpixel((7, 7), 1)
+		elif hour == 7:		# seven
+			image.putpixel((3, 7), 1)
+			image.putpixel((4, 7), 1)
+			image.putpixel((5, 7), 1)
+			image.putpixel((6, 7), 1)
+			image.putpixel((7, 7), 1)
 
-		elif hour ==8:	#eight
+		elif hour == 8:		# eight
 			image.putpixel((3, 3), 1)
 			image.putpixel((4, 3), 1)
 			image.putpixel((5, 3), 1)
 			image.putpixel((6, 3), 1)
 			image.putpixel((7, 3), 1)
 
-		elif hour ==9:	#nine
-	                image.putpixel((0, 3), 1)
-        	        image.putpixel((1, 3), 1)
-                	image.putpixel((2, 3), 1)
-	                image.putpixel((3, 3), 1)
+		elif hour == 9:		# nine
+			image.putpixel((0, 3), 1)
+			image.putpixel((1, 3), 1)
+			image.putpixel((2, 3), 1)
+			image.putpixel((3, 3), 1)
 
-		elif hour ==10:	#ten
-       	        	image.putpixel((7, 3), 1)
-	                image.putpixel((7, 4), 1)
-        	        image.putpixel((7, 5), 1)
+		elif hour == 10:	# ten
+			image.putpixel((7, 3), 1)
+			image.putpixel((7, 4), 1)
+			image.putpixel((7, 5), 1)
 
-		elif hour ==11:	#eleven
-                	image.putpixel((2, 5), 1)
-	                image.putpixel((3, 5), 1)
-        	        image.putpixel((4, 5), 1)
-                	image.putpixel((5, 5), 1)
-	                image.putpixel((6, 5), 1)
-        	        image.putpixel((7, 5), 1)
+		elif hour == 11:	# eleven
+			image.putpixel((2, 5), 1)
+			image.putpixel((3, 5), 1)
+			image.putpixel((4, 5), 1)
+			image.putpixel((5, 5), 1)
+			image.putpixel((6, 5), 1)
+			image.putpixel((7, 5), 1)
 
-		else:	#twelve
-        	        image.putpixel((0, 5), 1)
-	                image.putpixel((1, 5), 1)
-        	        image.putpixel((2, 5), 1)
-                	image.putpixel((3, 5), 1)
-	                image.putpixel((5, 5), 1)
-        	        image.putpixel((6, 5), 1)
+		else:	# twelve
+			image.putpixel((0, 5), 1)
+			image.putpixel((1, 5), 1)
+			image.putpixel((2, 5), 1)
+			image.putpixel((3, 5), 1)
+			image.putpixel((5, 5), 1)
+			image.putpixel((6, 5), 1)
 
-		# update the output drivers
-        	device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-        # admin displays ENGLISH
-        # these allow the variuos setup and status displays to be
-        # language specific without need to change the main code        
+	# Admin displays ENGLISH
+	# These allow the various setup and status displays to be
+	# language specific without need to change the main code        
 
-        def init(self):
+	def init(self):		# Display 'INIT'
 		image = Image.new('1', (8, 8))
 		image.putpixel((1, 3), 1)
 		image.putpixel((2, 3), 1)
 		image.putpixel((4, 3), 1)
 		image.putpixel((7, 3), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-        def error(self):
+	def error(self):	# Display 'E E E'
 		image = Image.new('1', (8, 8))
 		image.putpixel((2, 5), 1)
 		image.putpixel((4, 5), 1)
 		image.putpixel((6, 5), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-        def high(self,state):   # display or clear 'H'
+	def high(self,state):   # Display or clear 'H'
 		image = Image.new('1', (8, 8))
+		if state == True:
+			image.putpixel((0, 0), 1)
+		else:
+			image.putpixel((0, 0), 0)
 
-                if state == True:
-                        image.putpixel((0, 0), 1)
-
-                else:
-                        image.putpixel((0, 0), 0)
-
-
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
 
-        def low(self,state):    # display or clear 'L'
+	def low(self,state):    # Display or clear 'L'
 		image = Image.new('1', (8, 8))
-
-                if state == True:       
+		if state == True:       
 			image.putpixel((0, 2), 1)
-                else:
+		else:
 			image.putpixel((0, 2), 0)
 
+		# Update the output drivers
+		self.device.display(image)
 
-                # update the output drivers
-                device.display(image)
-
-	def test(self):		#display the work test to indicate you are entering demo mode
-                image = Image.new('1', (8, 8))
+	def test(self):		# Display the word TEST to indicate you are entering demo mode
+		image = Image.new('1', (8, 8))
 		image.putpixel((4, 1), 1)
 		image.putpixel((5, 1), 1)
 		image.putpixel((5, 2), 1)
 		image.putpixel((6, 2), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def align(self):	#display alignment screen
+	def align(self):	# Display alignment screen
 		image = Image.new('1', (8, 8))
-                image.putpixel((0, 0), 1)
-                image.putpixel((6, 0), 1)
-                image.putpixel((7, 0), 1)
-                image.putpixel((6, 1), 1)
-                image.putpixel((7, 1), 1)
-                image.putpixel((2, 3), 1)
-                image.putpixel((3, 3), 1)
-                image.putpixel((2, 4), 1)
-                image.putpixel((3, 4), 1)
-                image.putpixel((0, 7), 1)
-                image.putpixel((7, 7), 1)
+		image.putpixel((0, 0), 1)
+		image.putpixel((6, 0), 1)
+		image.putpixel((7, 0), 1)
+		image.putpixel((6, 1), 1)
+		image.putpixel((7, 1), 1)
+		image.putpixel((2, 3), 1)
+		image.putpixel((3, 3), 1)
+		image.putpixel((2, 4), 1)
+		image.putpixel((3, 4), 1)
+		image.putpixel((0, 7), 1)
+		image.putpixel((7, 7), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def pixel(self,x,y):		#allows external app to set an individual pixel
+	def pixel(self,x,y):		# Allows external app to set an individual pixel
 		image = Image.new('1', (8, 8))
-                image.putpixel((x, y), 1)
+		image.putpixel((x, y), 1)
 
-		# update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def clear(self):	# clear the current display
+	def clear(self):		# Clear the current display
 		image = Image.new('1', (8, 8))
-		# update the output drivers
-                device.display(image)
 
-	def contrast(self,level):	# set the birghtness level
+		# Update the output drivers
+		self.device.display(image)
+
+	def contrast(self,level):	# Set the brightness level
 		if level > 255 or level < 0:
 			return
-		device.contrast(level)
+		self.device.contrast(level)

--- a/timewrd5ca_fr.py
+++ b/timewrd5ca_fr.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
 # Python Class for use on word clock project  
-# Assumes and 8x8 matrix common anode type
+# Assumes an 8x8 matrix common anode type
 # David Saul 2018
 # This is configured for the PCB layout REV 4 onwards
 
 # From version 5
-# 	class has changed to use the luma.led_matrix libuary
-# 	this is not compatable with earlier vesions using the max7219 which is
-#	if effectcivly obsolete from Dec 2017
+# 	Class has changed to use the luma.led_matrix library
+# 	This is not compatible with earlier vesions using the max7219 library which is
+#	if effectively obsolete from Dec 2017
 #
-#	each language has it's own timewrd file in the format timewrd5ca_eng.py
-#	this avoids this file getting too ungainly and also makes it eaiser
-#	to add support for other display in the future
+#	Each language has it's own timewrd file in the format timewrd5ca_eng.py
+#	This avoids this file getting too ungainly and also makes it easier
+#	to add support for other displays in the future
 #
-#	support for various status symbol display has changed
+#	Support for various status symbol display has changed
 #
 #
 # ++++++++++++++++
@@ -25,81 +25,64 @@
 #
 # This class is written to work with the TFWordclock App version 5 and higher
 
-# Because of the change of libuary some version 4 features are slightly different / no longer supported
-#
-#
-# --- display rotation  - this is now controlled by setting the variable 'rotation' below
-# --- only english and French support currently - can add Dutch if there is interest
-# --- blink to indicate time within 5 minute incruments - no plans to re-impliment
-# --- the various warning are not impliemented as 'count downs' rather than moving bars
+# Because of the change of library some version 4 features are slightly different
+# --- the various warnings are now implemented as 'count downs' rather than moving bars
 
 
 # luma.led_matrix libuary - Richard Hull
 # https://github.com/rm-hull/luma.led_matrix
 #
 
+from __future__ import print_function, division
+
 from luma.core.interface.serial import spi, noop
 from luma.core.render import canvas
 from luma.led_matrix.device import max7219
 from time import sleep
-
-#-----------------------------------------------------
-rotation = 0		#set global rotate (0,1,2,3)
-#-----------------------------------------------------
-
-
-serial = spi(port=0, device=0, gpio=noop())
-device = max7219(serial, rotate = rotation)
-
-
-import math
 from PIL import Image
 
 
 # French Class
 class DMS_wrdck:
 
+	def __init__(self, rotation = 0):
+		serial = spi(port=0, device=0, gpio=noop())
+		self.device = max7219(serial, rotate = rotation)
 
-	def ckdisp(self,min,hour, prefix=False):
+	def ckdisp(self,min,hour, prefix=False, blink='none'):
 
-
-		# Perfor basic error check on variables
-	        if min < 0 or min > 59:
-        		return
-	        if hour < -1 or hour > 24:
-        	        return
+		# Perform basic error check on variables
+		if min < 0 or min > 59:
+			return
+		if hour < -1 or hour > 24:
+			return
 
 	        # Clear the display first by generating new image
-
 		image = Image.new('1', (8, 8))
 
-		# Display additional charater if needed
-		if prefix == 'A':		#Display astrix - for time setting mode
+		# Display additional character if needed
+		if prefix == 'A':		# Display astrix
 			image.putpixel((2, 6), 1)
-		elif prefix == 'V':		#Display EN and number - to indicate version number
+		elif prefix == 'V':		# Display EN and number - to indicate version number
 			image.putpixel((4, 7), 1)
 			image.putpixel((5, 7), 1)
 		else:
 			pass
 
-                # Correct from 24 hour to 12
-                if hour == 0:
-                        hour =1
+		# Correct from 24 hour to 12
+		if hour == 0:
+			hour = 1
 
-		# Display minutes past / to the hour in to nearest 15 minute 'slot'
+		# Display minutes past / to the hour in the nearest 15 minute 'slot'
 
-#	        print "sub ",hour,":", min              #For debug only
-
-
-		# Sort out special cases for midnight and midday, but surpress for count downs etc
-                if min < 8 and prefix == False and hour == 12:
+		# Sort out special cases for midnight and midday, but supress for count downs etc
+		if min < 8 and prefix == False and hour == 12:
 			image.putpixel((0, 5), 1)
 			image.putpixel((2, 5), 1)
 			image.putpixel((5, 5), 1)
 			image.putpixel((6, 5), 1)
 
-
-                elif min < 8 and prefix == False and  hour == 0:
+		elif min < 8 and prefix == False and hour == 0:
 			image.putpixel((2, 7), 1)
 			image.putpixel((3, 7), 1)
 			image.putpixel((5, 7), 1)
@@ -107,14 +90,13 @@ class DMS_wrdck:
 			image.putpixel((7, 7), 1)
 			image.putpixel((7, 6), 1)
 
-
-                elif min > 52 and hour == 11:
+		elif min > 52 and hour == 11:
 			image.putpixel((0, 5), 1)
 			image.putpixel((2, 5), 1)
 			image.putpixel((5, 5), 1)
 			image.putpixel((6, 5), 1)
 
-                elif min > 52 and hour == 23:
+		elif min > 52 and hour == 23:
 			image.putpixel((2, 7), 1)
 			image.putpixel((3, 7), 1)
 			image.putpixel((5, 7), 1)
@@ -122,238 +104,228 @@ class DMS_wrdck:
 			image.putpixel((7, 7), 1)
 			image.putpixel((7, 6), 1)
 
+		# Everything else - hours
+		else:   
 
-                # Everything else - hours
-                else:   
-			
-                        # Increment 'hour' for > 30 mins past the hour and you are not in demo
-                        if min > 37 and hour !=-1:
-                                hour = hour +1
-                                if hour == 24:
-                                        hour = 1        
-
+			# Increment 'hour' for > 30 mins past the hour and you are not in demo
+			if min > 37 and hour !=-1:
+				hour = hour + 1
+			if hour == 24:
+				hour = 1        
 
 			# Display the hours
 			if hour == -1: # blank hour display
 				pass
 
-			elif hour == 1 or hour == 13:	#one
-		                image.putpixel((1, 2), 1)
-	        	        image.putpixel((2, 3), 1)
-		                image.putpixel((3, 3), 1)
+			elif hour == 1 or hour == 13:	# one
+				image.putpixel((1, 2), 1)
+				image.putpixel((2, 3), 1)
+				image.putpixel((3, 3), 1)
 
-			elif hour ==2 or hour == 14:	#two
+			elif hour == 2 or hour == 14:	# two
 				image.putpixel((0, 0), 1)
-                		image.putpixel((2, 0), 1)
-	                	image.putpixel((3, 0), 1)
-	                	image.putpixel((6, 0), 1)
+				image.putpixel((2, 0), 1)
+				image.putpixel((3, 0), 1)
+				image.putpixel((6, 0), 1)
 
-			elif hour ==3 or hour == 15:	#three
-        		        image.putpixel((0, 1), 1)
-	        	        image.putpixel((1, 1), 1)
-        	        	image.putpixel((2, 1), 1)
-        		        image.putpixel((4, 1), 1)
-        		        image.putpixel((5, 1), 1)
+			elif hour == 3 or hour == 15:	# three
+				image.putpixel((0, 1), 1)
+				image.putpixel((1, 1), 1)
+				image.putpixel((2, 1), 1)
+				image.putpixel((4, 1), 1)
+				image.putpixel((5, 1), 1)
 
-			elif hour ==4 or hour == 16:	#four
-                		image.putpixel((0, 2), 1)
-		                image.putpixel((1, 2), 1)
-        		        image.putpixel((2, 2), 1)
-		                image.putpixel((3, 2), 1)
-		                image.putpixel((4, 2), 1)
-		                image.putpixel((5, 2), 1)
+			elif hour == 4 or hour == 16:	# four
+				image.putpixel((0, 2), 1)
+				image.putpixel((1, 2), 1)
+				image.putpixel((2, 2), 1)
+				image.putpixel((3, 2), 1)
+				image.putpixel((4, 2), 1)
+				image.putpixel((5, 2), 1)
 
-			elif hour ==5 or hour == 17:	#five
-	        	        image.putpixel((0, 3), 1)
-        	        	image.putpixel((0, 4), 1)
-	        	        image.putpixel((1, 4), 1)
-        	        	image.putpixel((2, 4), 1)
+			elif hour == 5 or hour == 17:	# five
+				image.putpixel((0, 3), 1)
+				image.putpixel((0, 4), 1)
+				image.putpixel((1, 4), 1)
+				image.putpixel((2, 4), 1)
 
-			elif hour ==6 or hour == 18:	#six
-        	        	image.putpixel((4, 0), 1)
-	        	        image.putpixel((5, 0), 1)
-        	        	image.putpixel((6, 0), 1)
+			elif hour == 6 or hour == 18:	# six
+				image.putpixel((4, 0), 1)
+				image.putpixel((5, 0), 1)
+				image.putpixel((6, 0), 1)
 
-			elif hour ==7 or hour == 19:	#seven
-		                image.putpixel((5, 1), 1)
-        		        image.putpixel((5, 2), 1)
-                		image.putpixel((6, 2), 1)
-		                image.putpixel((7, 2), 1)
+			elif hour == 7 or hour == 19:	# seven
+				image.putpixel((5, 1), 1)
+				image.putpixel((5, 2), 1)
+				image.putpixel((6, 2), 1)
+				image.putpixel((7, 2), 1)
 
-			elif hour ==8 or hour == 20:	#eight
+			elif hour == 8 or hour == 20:	# eight
 				image.putpixel((1, 3), 1)
 				image.putpixel((4, 3), 1)
 				image.putpixel((5, 3), 1)
 				image.putpixel((6, 3), 1)
 
-			elif hour ==9 or hour == 21:	#nine
-		                image.putpixel((2, 3), 1)
-        		        image.putpixel((3, 3), 1)
-                		image.putpixel((4, 3), 1)
-		                image.putpixel((7, 3), 1)
+			elif hour == 9 or hour == 21:	# nine
+				image.putpixel((2, 3), 1)
+				image.putpixel((3, 3), 1)
+				image.putpixel((4, 3), 1)
+				image.putpixel((7, 3), 1)
 
-			elif hour ==10 or hour == 22:	#ten
-       	        		image.putpixel((0, 0), 1)
-	                	image.putpixel((5, 0), 1)
-	        	        image.putpixel((6, 0), 1)
+			elif hour == 10 or hour == 22:	# ten
+				image.putpixel((0, 0), 1)
+				image.putpixel((5, 0), 1)
+				image.putpixel((6, 0), 1)
 
-			elif hour ==11 or hour == 23:	#eleven
-                		image.putpixel((2, 1), 1)
-	                	image.putpixel((3, 1), 1)
-	        	        image.putpixel((6, 1), 1)
-        	        	image.putpixel((7, 1), 1)
+			elif hour == 11 or hour == 23:	# eleven
+				image.putpixel((2, 1), 1)
+				image.putpixel((3, 1), 1)
+				image.putpixel((6, 1), 1)
+				image.putpixel((7, 1), 1)
 
-			else:	#twelve 
-        		        image.putpixel((0, 0), 1)
-	        	        image.putpixel((1, 0), 1)
-        	        	image.putpixel((3, 0), 1)
-	                	image.putpixel((7, 0), 1)
-		                image.putpixel((7, 1), 1)
+			else:	# twelve 
+				image.putpixel((0, 0), 1)
+				image.putpixel((1, 0), 1)
+				image.putpixel((3, 0), 1)
+				image.putpixel((7, 0), 1)
+				image.putpixel((7, 1), 1)
 
-			#display 'Heure' - unless displaying version number or count mode
+			# Display 'Heure' - unless displaying version number or count mode
 			if (prefix != 'V' and  min != 0 and hour != -1) or prefix == 'T':
-			        image.putpixel((3, 4), 1)
-			        image.putpixel((4, 4), 1)
-			        image.putpixel((5, 4), 1)
-		        	image.putpixel((6, 4), 1)
-			        image.putpixel((7, 4), 1)
+				image.putpixel((3, 4), 1)
+				image.putpixel((4, 4), 1)
+				image.putpixel((5, 4), 1)
+				image.putpixel((6, 4), 1)
+				image.putpixel((7, 4), 1)
 
+				# Check for special case - add plural
+				if hour > 1:	#plural
+					image.putpixel((7, 5), 1)
 
-                        # Check for special case - add plural
-        	                if hour > 1:	#plural
-                	           	image.putpixel((7, 5), 1)
+			if min < 8:
+				pass    
 
-
-                        if min < 8:
-                                pass    
-
-                        elif min < 23:		#et & quarter
+			elif min < 23:		# et & quarter
 				image.putpixel((0, 6), 1)
-		                image.putpixel((1, 6), 1)
+				image.putpixel((1, 6), 1)
 
-		                image.putpixel((3, 6), 1)
-		                image.putpixel((4, 6), 1)
-		                image.putpixel((5, 6), 1)
-		                image.putpixel((6, 6), 1)
-		                image.putpixel((7, 6), 1)
+				image.putpixel((3, 6), 1)
+				image.putpixel((4, 6), 1)
+				image.putpixel((5, 6), 1)
+				image.putpixel((6, 6), 1)
+				image.putpixel((7, 6), 1)
 
-                        elif min < 38:		#et & half
-		                image.putpixel((0, 6), 1)
-		                image.putpixel((1, 6), 1)
+			elif min < 38:		# et & half
+				image.putpixel((0, 6), 1)
+				image.putpixel((1, 6), 1)
 
-		                image.putpixel((0, 7), 1)
-		                image.putpixel((1, 7), 1)
-		                image.putpixel((2, 7), 1)
-		                image.putpixel((3, 7), 1)
-		                image.putpixel((4, 7), 1)
+				image.putpixel((0, 7), 1)
+				image.putpixel((1, 7), 1)
+				image.putpixel((2, 7), 1)
+				image.putpixel((3, 7), 1)
+				image.putpixel((4, 7), 1)
 
+			elif min < 53:		# minus & quarter
+				image.putpixel((0, 5), 1)
+				image.putpixel((1, 5), 1)
+				image.putpixel((2, 5), 1)
+				image.putpixel((3, 5), 1)
+				image.putpixel((4, 5), 1)
 
-                        elif min < 53:		#minus & quarter
-		                image.putpixel((0, 5), 1)
-		                image.putpixel((1, 5), 1)
-		                image.putpixel((2, 5), 1)
-		                image.putpixel((3, 5), 1)
-		                image.putpixel((4, 5), 1)
+				image.putpixel((3, 6), 1)
+				image.putpixel((4, 6), 1)
+				image.putpixel((5, 6), 1)
+				image.putpixel((6, 6), 1)
+				image.putpixel((7, 6), 1)
 
-		                image.putpixel((3, 6), 1)
-		                image.putpixel((4, 6), 1)
-		                image.putpixel((5, 6), 1)
-		                image.putpixel((6, 6), 1)
-		                image.putpixel((7, 6), 1)
+		# Update the output drivers
+		self.device.display(image)
 
+        # Admin displays FRENCH
+        # These allow the various setup and status displays to be
+	# language specific without need to change the main code
 
-		# update the output drivers
-        	device.display(image)
-
-        # admin displays FRENCH
-        # these display the variuos setup and status displays
-
-        def init(self):
+	def init(self):
 		image = Image.new('1', (8, 8))
 		image.putpixel((3, 7), 1)
 		image.putpixel((5, 7), 1)
 		image.putpixel((7, 7), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-        def error(self):
+	def error(self):
 		image = Image.new('1', (8, 8))
 		image.putpixel((3, 3), 1)
 		image.putpixel((4, 4), 1)
 		image.putpixel((6, 4), 1)
 		image.putpixel((7, 4), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-        def high(self,state):   # display or clear 'H' (Haute)
+	def high(self,state):   # Display or clear 'H' (Haute)
 		image = Image.new('1', (8, 8))
+		if state == True:
+			image.putpixel((1, 3), 1)
+		else:
+			image.putpixel((1, 3), 0)
 
-                if state == True:
-                        image.putpixel((1, 3), 1)
-
-                else:
-                        image.putpixel((1, 3), 0)
-
-
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
 
-        def low(self,state):    # display or clear 'F' (Faible)
+	def low(self,state):    # Display or clear 'F' (Faible)
 		image = Image.new('1', (8, 8))
-
-                if state == True:
+		if state == True:
 			image.putpixel((7, 3), 1)
-                else:
+		else:
 			image.putpixel((7, 3), 0)
 
+		# Update the output drivers
+		self.device.display(image)
 
-                # update the output drivers
-                device.display(image)
-
-	def test(self):		#display the word test to indicate you are entering demo mode
-				# should the word 'tester' but cannot fit that in
-                image = Image.new('1', (8, 8))
+	def test(self):		# Display the word TEST to indicate you are entering demo mode
+				# Should be the word 'tester' but cannot fit that in
+		image = Image.new('1', (8, 8))
 		image.putpixel((7, 2), 1)
 		image.putpixel((7, 4), 1)
 		image.putpixel((7, 5), 1)
 		image.putpixel((7, 6), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def align(self):	#display alignment screen
+	def align(self):	# Display alignment screen
 		image = Image.new('1', (8, 8))
-                image.putpixel((0, 0), 1)
-                image.putpixel((6, 0), 1)
-                image.putpixel((7, 0), 1)
-                image.putpixel((6, 1), 1)
-                image.putpixel((7, 1), 1)
-                image.putpixel((2, 3), 1)
-                image.putpixel((3, 3), 1)
-                image.putpixel((2, 4), 1)
-                image.putpixel((3, 4), 1)
-                image.putpixel((0, 7), 1)
-                image.putpixel((7, 7), 1)
+		image.putpixel((0, 0), 1)
+		image.putpixel((6, 0), 1)
+		image.putpixel((7, 0), 1)
+		image.putpixel((6, 1), 1)
+		image.putpixel((7, 1), 1)
+		image.putpixel((2, 3), 1)
+		image.putpixel((3, 3), 1)
+		image.putpixel((2, 4), 1)
+		image.putpixel((3, 4), 1)
+		image.putpixel((0, 7), 1)
+		image.putpixel((7, 7), 1)
 
-                # update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def pixel(self,x,y):		#allows external app to set an individual pixel
+	def pixel(self,x,y):		# Allows external app to set an individual pixel
 		image = Image.new('1', (8, 8))
-                image.putpixel((x, y), 1)
+		image.putpixel((x, y), 1)
 
-		# update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def clear(self):	# clear the current display
+	def clear(self):		# Clear the current display
 		image = Image.new('1', (8, 8))
-		# update the output drivers
-                device.display(image)
+		# Update the output drivers
+		self.device.display(image)
 
-	def contrast(self,level):	# set the birghtness level
+	def contrast(self,level):	# Set the brightness level
 		if level > 255 or level < 0:
 			return
-		device.contrast(level)
+		self.device.contrast(level)

--- a/timewrd5ca_ger.py
+++ b/timewrd5ca_ger.py
@@ -19,7 +19,7 @@
 #
 # +++++++++++++++
 # +	        +
-# +    DUTCH    +
+# +   GERMAN    +
 # +	        +
 # +++++++++++++++
 #
@@ -42,7 +42,7 @@ from time import sleep
 from PIL import Image
 
 
-# Dutch Class
+# German Class
 class DMS_wrdck:
 
 	def __init__(self, rotation = 0):
@@ -61,12 +61,10 @@ class DMS_wrdck:
 		image = Image.new('1', (8, 8))
 
 		# Display additional character if needed
-		if prefix == 'A':		# Display 'N' [Nieuw]
-			image.putpixel((7,5), 1)
-		elif prefix == 'V':		# Display 'VER' - to indicate version number
-			image.putpixel((5, 1), 1)
-			image.putpixel((6, 1), 1)
-			image.putpixel((7, 1), 1)
+		if prefix == 'A':		# Display '*'
+			image.putpixel((7,1), 1)
+		elif prefix == 'V':		# Display 'V' - to indicate version number
+			image.putpixel((0, 1), 1)
 		else:
 			pass
 
@@ -104,24 +102,24 @@ class DMS_wrdck:
 			pass
 
 		elif min == 1:	# five_past
-			image.putpixel((0, 1), 1)
-			image.putpixel((1, 1), 1)
-			image.putpixel((2, 1), 1)
+			image.putpixel((0, 0), 1)
+			image.putpixel((1, 0), 1)
+			image.putpixel((2, 0), 1)
+			image.putpixel((3, 0), 1)
 			image.putpixel((3, 1), 1)
 			image.putpixel((4, 1), 1)
 			image.putpixel((5, 1), 1)
 			image.putpixel((6, 1), 1)
-			image.putpixel((7, 1), 1)
 
 		elif min == 2:	# ten_past
 			image.putpixel((4, 0), 1)
 			image.putpixel((5, 0), 1)
 			image.putpixel((6, 0), 1)
 			image.putpixel((7, 0), 1)
+			image.putpixel((3, 1), 1)
 			image.putpixel((4, 1), 1)
 			image.putpixel((5, 1), 1)
 			image.putpixel((6, 1), 1)
-			image.putpixel((7, 1), 1)
 
 
 		elif min == 3:	# fifteen_past
@@ -130,72 +128,73 @@ class DMS_wrdck:
 			image.putpixel((2, 0), 1)
 			image.putpixel((3, 0), 1)
 			image.putpixel((4, 0), 1)
+			image.putpixel((5, 0), 1)
+			image.putpixel((6, 0), 1)
+			image.putpixel((7, 0), 1)
+			image.putpixel((3, 1), 1)
 			image.putpixel((4, 1), 1)
 			image.putpixel((5, 1), 1)
 			image.putpixel((6, 1), 1)
-			image.putpixel((7, 1), 1)
 
 		elif min == 4:	# twenty_past
 			image.putpixel((4, 0), 1)
 			image.putpixel((5, 0), 1)
 			image.putpixel((6, 0), 1)
 			image.putpixel((7, 0), 1)
+			image.putpixel((0, 1), 1)
+			image.putpixel((1, 1), 1)
+			image.putpixel((2, 1), 1)
 			image.putpixel((0, 2), 1)
 			image.putpixel((1, 2), 1)
 			image.putpixel((2, 2), 1)
 			image.putpixel((3, 2), 1)
-			image.putpixel((4, 2), 1)
-			image.putpixel((5, 2), 1)
-			image.putpixel((6, 2), 1)
-			image.putpixel((7, 2), 1)
 
 		elif min == 5:	# twenty5_past
+			image.putpixel((0, 0), 1)
+			image.putpixel((1, 0), 1)
+			image.putpixel((2, 0), 1)
+			image.putpixel((3, 0), 1)
 			image.putpixel((0, 1), 1)
 			image.putpixel((1, 1), 1)
 			image.putpixel((2, 1), 1)
-			image.putpixel((3, 1), 1)
 			image.putpixel((0, 2), 1)
 			image.putpixel((1, 2), 1)
 			image.putpixel((2, 2), 1)
 			image.putpixel((3, 2), 1)
-			image.putpixel((4, 2), 1)
-			image.putpixel((5, 2), 1)
-			image.putpixel((6, 2), 1)
-			image.putpixel((7, 2), 1)
 
 		elif min == 6:	# half_past
-			image.putpixel((4, 2), 1)
-			image.putpixel((5, 2), 1)
-			image.putpixel((6, 2), 1)
-			image.putpixel((7, 2), 1)
+			image.putpixel((0, 2), 1)
+			image.putpixel((1, 2), 1)
+			image.putpixel((2, 2), 1)
+			image.putpixel((3, 2), 1)
 
 		elif min == 7:	# twenty5_to
-			image.putpixel((0, 1), 1)
-			image.putpixel((1, 1), 1)
-			image.putpixel((2, 1), 1)
+			image.putpixel((0, 0), 1)
+			image.putpixel((1, 0), 1)
+			image.putpixel((2, 0), 1)
+			image.putpixel((3, 0), 1)
 			image.putpixel((3, 1), 1)
 			image.putpixel((4, 1), 1)
 			image.putpixel((5, 1), 1)
 			image.putpixel((6, 1), 1)
-			image.putpixel((7, 1), 1)
-			image.putpixel((4, 2), 1)
-			image.putpixel((5, 2), 1)
-			image.putpixel((6, 2), 1)
-			image.putpixel((7, 2), 1)
+			image.putpixel((0, 2), 1)
+			image.putpixel((1, 2), 1)
+			image.putpixel((2, 2), 1)
+			image.putpixel((3, 2), 1)
 
 		elif min == 8:	# twenty_to
 			image.putpixel((4, 0), 1)
 			image.putpixel((5, 0), 1)
 			image.putpixel((6, 0), 1)
 			image.putpixel((7, 0), 1)
+			image.putpixel((3, 1), 1)
 			image.putpixel((4, 1), 1)
 			image.putpixel((5, 1), 1)
 			image.putpixel((6, 1), 1)
-			image.putpixel((7, 1), 1)
-			image.putpixel((4, 2), 1)
-			image.putpixel((5, 2), 1)
-			image.putpixel((6, 2), 1)
-			image.putpixel((7, 2), 1)
+			image.putpixel((0, 2), 1)
+			image.putpixel((1, 2), 1)
+			image.putpixel((2, 2), 1)
+			image.putpixel((3, 2), 1)
 
 		elif min == 9:	# fifteen_to
 			image.putpixel((0, 0), 1)
@@ -203,159 +202,158 @@ class DMS_wrdck:
 			image.putpixel((2, 0), 1)
 			image.putpixel((3, 0), 1)
 			image.putpixel((4, 0), 1)
-			image.putpixel((0, 2), 1)
-			image.putpixel((1, 2), 1)
-			image.putpixel((2, 2), 1)
-			image.putpixel((3, 2), 1)
+			image.putpixel((5, 0), 1)
+			image.putpixel((6, 0), 1)
+			image.putpixel((7, 0), 1)
+			image.putpixel((0, 1), 1)
+			image.putpixel((1, 1), 1)
+			image.putpixel((2, 1), 1)
 
 		elif min == 10:	# ten_to
-
 			image.putpixel((4, 0), 1)
 			image.putpixel((5, 0), 1)
 			image.putpixel((6, 0), 1)
 			image.putpixel((7, 0), 1)
-			image.putpixel((0, 2), 1)
-			image.putpixel((1, 2), 1)
-			image.putpixel((2, 2), 1)
-			image.putpixel((3, 2), 1)
-
-		else:	# five_to
 			image.putpixel((0, 1), 1)
 			image.putpixel((1, 1), 1)
 			image.putpixel((2, 1), 1)
-			image.putpixel((3, 1), 1)
-			image.putpixel((0, 2), 1)
-			image.putpixel((1, 2), 1)
-			image.putpixel((2, 2), 1)
-			image.putpixel((3, 2), 1)
+
+		else:	# five_to
+			image.putpixel((0, 0), 1)
+			image.putpixel((1, 0), 1)
+			image.putpixel((2, 0), 1)
+			image.putpixel((3, 0), 1)
+			image.putpixel((0, 1), 1)
+			image.putpixel((1, 1), 1)
+			image.putpixel((2, 1), 1)
 
 		# Display the hours
 		if hour == -1:		# blank hour display
 			pass
 
 		elif hour == 1:		# one
-			image.putpixel((5, 4), 1)
-			image.putpixel((6, 4), 1)
-			image.putpixel((7, 4), 1)
-
-		elif hour == 2:		# two
-			image.putpixel((3, 4), 1)
-			image.putpixel((4, 4), 1)
-			image.putpixel((5, 4), 1)
-			image.putpixel((6, 4), 1)
-
-		elif hour == 3:		# three
-			image.putpixel((4, 6), 1)
-			image.putpixel((5, 6), 1)
-			image.putpixel((6, 6), 1)
-			image.putpixel((7, 6), 1)
-
-		elif hour == 4:		# four
-			image.putpixel((1, 5), 1)
-			image.putpixel((2, 5), 1)
-			image.putpixel((5, 5), 1)
-			image.putpixel((6, 5), 1)
-
-		elif hour == 5:		# five
-			image.putpixel((1, 5), 1)
-			image.putpixel((2, 5), 1)
-			image.putpixel((3, 5), 1)
-			image.putpixel((4, 5), 1)
-
-		elif hour == 6:		# six
-			image.putpixel((0, 3), 1)
-			image.putpixel((1, 3), 1)
-			image.putpixel((2, 3), 1)
-
-		elif hour == 7:		# seven
-			image.putpixel((3, 3), 1)
-			image.putpixel((4, 3), 1)
-			image.putpixel((5, 3), 1)
-			image.putpixel((6, 3), 1)
-			image.putpixel((7, 3), 1)
-
-		elif hour == 8:		# eight
 			image.putpixel((0, 6), 1)
 			image.putpixel((1, 6), 1)
 			image.putpixel((2, 6), 1)
 			image.putpixel((3, 6), 1)
 
-		elif hour == 9:		# nine
-			image.putpixel((0, 4), 1)
+		elif hour == 2:		# two
+			image.putpixel((0, 3), 1)
+			image.putpixel((1, 3), 1)
+			image.putpixel((2, 3), 1)
+			image.putpixel((3, 3), 1)
+
+		elif hour == 3:		# three
+			image.putpixel((4, 3), 1)
+			image.putpixel((5, 3), 1)
+			image.putpixel((6, 3), 1)
+			image.putpixel((7, 3), 1)
+
+		elif hour == 4:		# four
 			image.putpixel((1, 4), 1)
 			image.putpixel((2, 4), 1)
+			image.putpixel((3, 4), 1)
+			image.putpixel((4, 4), 1)
+
+		elif hour == 5:		# five
+			image.putpixel((4, 5), 1)
+			image.putpixel((5, 5), 1)
+			image.putpixel((6, 5), 1)
+			image.putpixel((7, 5), 1)
+
+		elif hour == 6:		# six
+			image.putpixel((3, 6), 1)
+			image.putpixel((4, 6), 1)
+			image.putpixel((5, 6), 1)
+			image.putpixel((6, 6), 1)
+			image.putpixel((7, 6), 1)
+
+		elif hour == 7:		# seven
+			image.putpixel((0, 4), 1)
+			image.putpixel((2, 4), 1)
+			image.putpixel((3, 4), 1)
+			image.putpixel((5, 4), 1)
 			image.putpixel((6, 4), 1)
 			image.putpixel((7, 4), 1)
 
-		elif hour == 10:	# ten
-			image.putpixel((0, 5), 1)
-			image.putpixel((2, 5), 1)
-			image.putpixel((5, 5), 1)
-			image.putpixel((7, 5), 1)
+		elif hour == 8:		# eight
+			image.putpixel((4, 2), 1)
+			image.putpixel((5, 2), 1)
+			image.putpixel((6, 2), 1)
+			image.putpixel((7, 2), 1)
 
-		elif hour == 11:	# eleven
+		elif hour == 9:		# nine
 			image.putpixel((0, 7), 1)
 			image.putpixel((1, 7), 1)
-			image.putpixel((7, 7), 1)
-
-		else:	# twelve
 			image.putpixel((2, 7), 1)
 			image.putpixel((3, 7), 1)
+
+		elif hour == 10:	# ten
 			image.putpixel((4, 7), 1)
 			image.putpixel((5, 7), 1)
 			image.putpixel((6, 7), 1)
 			image.putpixel((7, 7), 1)
 
+		elif hour == 11:	# eleven
+			image.putpixel((3, 4), 1)
+			image.putpixel((3, 5), 1)
+			image.putpixel((4, 5), 1)
+
+		else:	# twelve
+			image.putpixel((0, 5), 1)
+			image.putpixel((1, 5), 1)
+			image.putpixel((2, 5), 1)
+			image.putpixel((3, 5), 1)
+			image.putpixel((4, 5), 1)
+
 		# Update the output drivers
 		self.device.display(image)
 
-	# Admin displays DUTCH
+	# Admin displays GERMAN
 	# These allow the various setup and status displays to be
 	# language specific without need to change the main code	 
 
-	def init(self):		# Display 'IN'
+	def init(self):		# Display 'INIT'
 		image = Image.new('1', (8, 8))
-		image.putpixel((5, 0), 1)
-		image.putpixel((7, 0), 1)
+		image.putpixel((2, 4), 1)
+		image.putpixel((7, 4), 1)
+		image.putpixel((7, 3), 1)
+		image.putpixel((7, 2), 1)
 
 		# Update the output drivers
 		self.device.display(image)
 
-	def error(self):	# Display 'FO' (Error = Fout)
+	def error(self):	# Display 'F' (Fehler)
 		image = Image.new('1', (8, 8))
-		image.putpixel((3, 1), 1)
-		image.putpixel((4, 1), 1)
+		image.putpixel((0, 0), 1)
 
 		# Update the output drivers
 		self.device.display(image)
 
-	def high(self,state):   # Display or clear 'H'
+	def high(self,state):   # Display or clear 'H' (Hoch)
 		image = Image.new('1', (8, 8))
 		if state == True:
-			image.putpixel((4, 2), 1)
+			image.putpixel((0, 2), 1)
 		else:
-			image.putpixel((4, 2), 0)
+			image.putpixel((0, 2), 0)
 
 		# Update the output drivers
 		self.device.display(image)
 
 
-	def low(self,state):    # Display or clear 'L'
+	def low(self,state):    # Display or clear 'N' (Niedrig)
 		image = Image.new('1', (8, 8))
 		if state == True:	
-			image.putpixel((6, 2), 1)
+			image.putpixel((7, 0), 1)
 		else:
-			image.putpixel((6, 2), 0)
+			image.putpixel((7, 0), 0)
 
 		# Update the output drivers
 		self.device.display(image)
 
-	def test(self):		# Display the word TEST to indicate you are entering demo mode
+	def test(self):		# Display T to indicate you are entering demo mode
 		image = Image.new('1', (8, 8))
-		image.putpixel((0, 5), 1)
-		image.putpixel((1, 4), 1)
-		image.putpixel((2, 3), 1)
-		image.putpixel((3, 4), 1)
+		image.putpixel((7, 2), 1)
 
 		# Update the output drivers
 		self.device.display(image)


### PR DESCRIPTION
Minute blinking, rotation as argument, German support, Python 3 support

Re-implemented minute blinking for all languages except French. When
minute blinking is not specified, proper 5-minute interval rounding
maintained.
Rotation can again be specified as an argument. Implemented by
initializing the luma library in the __init__ function.
Added German support using the template specified in the Arduino code.
A proper template is still missing.
Code now runs under both python2 and python3. All used libraries are
already available for both python2 and python3. Code tested with both
Python 2 and 3.
Cleaned up comments (mostly spelling).
Indentation now only uses Tabs. Python3 does not like mixed spaces and
tabs in indentations.
Updated main README

Note: Proper German template is missing.